### PR TITLE
feat: Turn into class

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,3 +16,5 @@ jobs:
         run: deno lint
       - name: Run type check
         run: deno check --remote ./**/*.ts
+      - name: Run test
+        run: deno test

--- a/.github/workflows/udd.yml
+++ b/.github/workflows/udd.yml
@@ -17,6 +17,7 @@ jobs:
         run: >
           deno run --allow-net --allow-read --allow-write=deps/
           --allow-run=deno https://deno.land/x/udd@0.7.2/main.ts deps/*.ts
+          --test="deno test"
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
         with:

--- a/deps/assert.ts
+++ b/deps/assert.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.224.0/assert/mod.ts";

--- a/deps/async.ts
+++ b/deps/async.ts
@@ -1,0 +1,1 @@
+export * from "https://deno.land/std@0.224.0/async/mod.ts";

--- a/deps/scrapbox.ts
+++ b/deps/scrapbox.ts
@@ -1,0 +1,1 @@
+export * from "https://raw.githubusercontent.com/takker99/scrapbox-userscript-std/0.26.0/browser/dom/mod.ts";

--- a/mod.test.ts
+++ b/mod.test.ts
@@ -1,0 +1,166 @@
+/// <reference lib="deno.ns" />
+
+import { assertEquals } from "./deps/assert.ts";
+import { delay } from "./deps/async.ts";
+import { parse } from "./deps/vim-like-key-notation.ts";
+import { Command, Mousetrap } from "./mod.ts";
+
+const mockTarget = {
+  listeners: new Set<EventListener>(),
+  dispatchEvent(vimKey: string) {
+    const res = parse(vimKey);
+    if (!res.ok) {
+      const e = new Error();
+      e.name = res.value.name;
+      e.message = res.value.message;
+      throw e;
+    }
+    for (const listener of this.listeners) {
+      listener(
+        {
+          ...res.value,
+          isTrusted: true,
+          preventDefault: () => {},
+          stopPropagation: () => {},
+        } as KeyboardEvent,
+      );
+    }
+  },
+  addEventListener(_: string, listener: EventListener) {
+    this.listeners.add(listener);
+  },
+  removeEventListener(_: string, listener: EventListener) {
+    this.listeners.delete(listener);
+  },
+};
+
+Deno.test("ScrapBindings", async (t) => {
+  await t.step("initial state", () => {
+    const bindings = new Mousetrap(mockTarget);
+
+    assertEquals(bindings["bindings"], new Map<string, Command>());
+    assertEquals(bindings.currentSequence, "");
+  });
+
+  await t.step("registration", async (t) => {
+    const mockCommand: Command = (_) => {};
+    await t.step("bind single key sequence", () => {
+      const bindings = new Mousetrap(mockTarget);
+
+      bindings.bind("gg", mockCommand);
+
+      const expectedBindings = new Map<string, Command>([["gg", mockCommand]]);
+      assertEquals(bindings["bindings"], expectedBindings);
+    });
+    await t.step("bind multiple key sequences", async (t) => {
+      await t.step("by map", () => {
+        const bindings = new Mousetrap(mockTarget);
+
+        const keyBindings = new Map<string, Command>([
+          ["gg", mockCommand],
+          ["G", mockCommand],
+          ["d", mockCommand],
+        ]);
+
+        bindings.bind(keyBindings);
+
+        const expectedBindings = new Map<string, Command>([
+          ["gg", mockCommand],
+          ["G", mockCommand],
+          ["d", mockCommand],
+        ]);
+        assertEquals(bindings["bindings"], expectedBindings);
+      });
+      await t.step("by object", () => {
+        const bindings = new Mousetrap(mockTarget);
+
+        bindings.bind({ gg: mockCommand, G: mockCommand, d: mockCommand });
+
+        const expectedBindings = new Map<string, Command>([
+          ["gg", mockCommand],
+          ["G", mockCommand],
+          ["d", mockCommand],
+        ]);
+        assertEquals(bindings["bindings"], expectedBindings);
+      });
+    });
+    await t.step("unbind key sequences", () => {
+      const bindings = new Mousetrap(mockTarget);
+
+      bindings.bind({ gg: mockCommand, G: mockCommand, d: mockCommand });
+
+      bindings.unbind("gg", "G");
+
+      const expectedBindings = new Map<string, Command>([["d", mockCommand]]);
+      assertEquals(bindings["bindings"], expectedBindings);
+    });
+    await t.step("unbind key sequences", () => {
+      const bindings = new Mousetrap(mockTarget);
+
+      bindings.bind({ gg: mockCommand, G: mockCommand, d: mockCommand });
+
+      bindings.reset();
+
+      const expectedBindings = new Map<string, Command>();
+      assertEquals(bindings["bindings"], expectedBindings);
+    });
+  });
+
+  await t.step("key event", async (t) => {
+    let last: KeyboardEvent | undefined;
+    const mockCommand: Command = (e) => last = e;
+    const bindings = new Mousetrap(mockTarget, { flushInterval: 50 });
+    bindings.bind({
+      gg: mockCommand,
+      G: mockCommand,
+      d: mockCommand,
+      g: mockCommand,
+      rr: mockCommand,
+    });
+
+    await t.step("single key sequence", () => {
+      assertEquals(last, undefined);
+      mockTarget.dispatchEvent("k");
+      assertEquals(last, undefined);
+      mockTarget.dispatchEvent("G");
+      assertEquals(last?.key, "G");
+      mockTarget.dispatchEvent("d");
+      assertEquals(last?.key, "d");
+    });
+    last = undefined;
+    await t.step("multiple key sequences", () => {
+      mockTarget.dispatchEvent("r");
+      mockTarget.dispatchEvent("r");
+      assertEquals(last?.key, "r");
+      last = undefined;
+      mockTarget.dispatchEvent("r");
+      mockTarget.dispatchEvent("k");
+      assertEquals(last, undefined);
+    });
+    last = undefined;
+    await t.step("pause", async () => {
+      mockTarget.dispatchEvent("r");
+      assertEquals(last, undefined);
+      assertEquals(bindings["_sequence"], "r");
+      await delay(100);
+      assertEquals(bindings["_sequence"], "");
+      mockTarget.dispatchEvent("g");
+      assertEquals(last, undefined);
+      await delay(100);
+      assertEquals(last?.key, "g");
+    });
+    last = undefined;
+    await t.step("cancel by another key", () => {
+      let text = "";
+      bindings.bind({
+        g: () => text += "g",
+        a: () => text += "a",
+      });
+      mockTarget.dispatchEvent("g");
+      assertEquals(text, "");
+      mockTarget.dispatchEvent("a");
+      assertEquals(text, "ga");
+    });
+    last = undefined;
+  });
+});

--- a/mod.ts
+++ b/mod.ts
@@ -15,126 +15,221 @@ export type { Result };
 const logger = createDebug("ScrapBindings:mod.ts");
 
 export type Command = (e: KeyboardEvent) => void;
+export type KeyBindings = Record<string, Command> | Map<string, Command>;
 
 /**
- * Represents the configuration options for initializing a binding.
+ * Represents the configuration options for {@link Mousetrap}.
  */
-export interface BindInit {
-  /** The target element to bind the key sequences to. */
-  target: Omit<EventTarget, "dispatchEvent">;
+export interface MousetrapOptions {
   /** A callback called whenever the sequence is updated. */
   onSequenceUpdate?: (sequence: string) => void;
   /** The interval in milliseconds to flush the sequence. */
   flushInterval?: number;
 }
 
-/** binds a set of key bindings to a target element.
+/** A key binding manager that binds key sequences to commands.
  *
- * The key bindings are a map of key sequences to commands.
  * The key sequences are in the Vim-like key notation format.
  *
- * @param keyBindings A map of key bindings to commands.
- * @param init The configuration options for initializing a binding.
- * @returns If the key bindings are valid, a function that removes the binding is returned. Otherwise, an array of error messages is returned.
+ * @example
+ * ```ts
+ * const bindings = new ScrapBindings(window, {
+ *  onSequenceUpdate: (sequence) => console.log(sequence),
+ * flushInterval: 1000,
+ * });
+ * bindings.bind("gg", () => console.log("go to the top"));
+ * bindings.bind("G", () => console.log("go to the bottom"));
+ * bindings.bind("d", (e) => {
+ *  e.preventDefault();
+ * console.log("delete");
+ * });
+ * bindings.bind("dd", () => console.log("delete the line"));
+ * bindings.bind("yy", () => console.log("copy the line"));
+ * bindings.bind("p", () => console.log("paste"));
+ * bindings.bind("u", () => console.log("undo"));
+ * bindings.bind("<C-r>", () => console.log("redo"));
+ *  ```
  */
-export const bind = (
-  keyBindings: Record<string, Command> | Map<string, Command>,
-  init: BindInit,
-): Result<() => void, [string, string][]> => {
-  const commands = checkKeyBindings(keyBindings);
-  if (Array.isArray(commands)) {
-    logger.error("Invalid key bindings", commands);
-    return { ok: false, value: commands };
+export class Mousetrap {
+  constructor(
+    /** The target element to bind the key sequences to. */
+    private target: Omit<EventTarget, "dispatchEvent">,
+    options?: MousetrapOptions,
+  ) {
+    this.onSequenceUpdate = options?.onSequenceUpdate;
+    this.flushInterval = options?.flushInterval ?? 1000;
   }
-  logger.debug("Binded the following commands:", commands);
 
-  let sequence = "";
-  const setSequence = (s: string) => {
-    sequence = s;
-    init.onSequenceUpdate?.(s);
-  };
-  let bestMatchCommand: (() => void) | undefined;
-  let filtered = new Map(commands);
-  let timer: number | undefined;
+  /** bind a set of key bindings
+   *
+   * The key bindings are a map of key sequences to commands.
+   *
+   * The key sequences are in the Vim-like key notation format.
+   *
+   * @param keyBindings A map of key bindings to commands.
+   * @returns an array of error messages
+   */
+  bind(keyBindings: KeyBindings): [string, string][];
+  /** bind a key bindings
+   *
+   * The key sequence is in the Vim-like key notation format.
+   *
+   * @param sequence a key sequence
+   * @param command a command to bind
+   * @returns an array of error messages
+   */
+  bind(sequence: string, command: Command): [string, string][];
+  bind(sequence: string | KeyBindings, command?: Command): [string, string][] {
+    const commands = checkKeyBindings(
+      typeof sequence === "string"
+        ? Object.fromEntries([[sequence, command!]])
+        : sequence,
+    );
+    if (Array.isArray(commands)) {
+      logger.error("Invalid key bindings", commands);
+      return commands;
+    }
+    for (const [sequence, command] of commands) {
+      this.bindings.set(sequence, command);
+      if (sequence.startsWith(this.currentSequence)) {
+        this.filtered.add(sequence);
+      }
+    }
+    logger.debug("Binded the following commands:", commands);
+    this.emitChange();
+    return [];
+  }
 
-  const reset = () => {
-    clearTimeout(timer);
-    setSequence("");
-    bestMatchCommand = undefined;
-    filtered = new Map(commands);
+  unbind(...keys: string[]): void {
+    for (const key of keys) {
+      this.bindings.delete(key);
+      this.filtered.delete(key);
+    }
+    this.emitChange();
+  }
+
+  reset(): void {
+    this.bindings.clear();
+    this.emitChange();
+  }
+  private bindings = new Map<string, Command>();
+
+  /** A callback called whenever the sequence is updated. */
+  private onSequenceUpdate?: (sequence: string) => void;
+
+  /** The interval in milliseconds to flush the sequence. */
+  private flushInterval: number;
+
+  private _sequence = "";
+  private set currentSequence(sequence: string) {
+    const changed = this._sequence !== sequence;
+    this._sequence = sequence;
+    if (changed) this.onSequenceUpdate?.(sequence);
+  }
+  get currentSequence(): string {
+    return this._sequence;
+  }
+
+  private prevBestMatchCommand: (() => void) | undefined;
+  private filtered = new Set<string>();
+  private timer: number | undefined;
+
+  private backToInitial = () => {
+    clearTimeout(this.timer);
+    this.currentSequence = "";
+    this.prevBestMatchCommand = undefined;
+    this.filtered = new Set(this.bindings.keys());
     logger.debug("reset the sequence");
   };
-  const run = (key: string, command: Command, e: KeyboardEvent) => {
-    logger.debug(`run ${key}`);
-    try {
-      command(e);
-    } catch (error: unknown) {
-      logger.error(error);
-    } finally {
-      reset();
-    }
-  };
 
-  const interval = init.flushInterval ?? 1000;
-
-  const handleKeydown = (e: KeyboardEvent) => {
+  private handleKeydown = (e: KeyboardEvent) => {
     if (!e.isTrusted) return;
     const vimKey = stringify(e);
     if (!vimKey) return;
-    clearTimeout(timer);
+    clearTimeout(this.timer);
     if (e.isComposing || e.key === "Process") {
-      reset();
+      this.backToInitial();
       return;
     }
-    setSequence(sequence + vimKey);
-    logger.debug("sequence", sequence);
-    let bestMatchCommand_: (() => void) | undefined;
-    for (const [key, command] of filtered) {
-      if (!key.startsWith(sequence)) filtered.delete(key);
-      if (sequence === key) bestMatchCommand_ = () => run(key, command, e);
+    this.currentSequence += vimKey;
+    logger.debug("sequence", this.currentSequence);
+    let bestMatchCommand: (() => void) | undefined;
+    for (const key of this.filtered) {
+      if (!key.startsWith(this.currentSequence)) this.filtered.delete(key);
+      if (this.currentSequence !== key) continue;
+      const command = this.bindings.get(key);
+      if (!command) {
+        this.filtered.delete(key);
+        continue;
+      }
+      bestMatchCommand = () => {
+        logger.debug(`run ${key}`);
+        try {
+          command(e);
+        } catch (error: unknown) {
+          logger.error(error);
+        } finally {
+          this.backToInitial();
+        }
+      };
     }
-    logger.debug(
-      `${filtered.size} candidates: ${[...filtered.keys()].join(", ")}`,
-    );
-    if (filtered.size > 0) bestMatchCommand = bestMatchCommand_;
-    if ((bestMatchCommand && filtered.size < 2)) {
-      const size = filtered.size;
-      bestMatchCommand();
-      // このターンの`KeyboardEvent`をまだ消費していないときは、もう一度`handleKeydown`を呼び出す
+    const size = this.filtered.size;
+    logger.debug(`${size} candidates: ${[...this.filtered.keys()].join(", ")}`);
+    if (size > 0) this.prevBestMatchCommand = bestMatchCommand;
+    if (this.prevBestMatchCommand && size < 2) {
+      // 完全一致するコマンド`bestMatchCommand`だけ残ったら、それを実行する
+      // 前回のターンで完全一致したコマンドと部分一致したコマンドがあり、今回のターンで前回部分一致したコマンドが全て外れたときは、前回完全一致したコマンド`this.prevBestMatchCommand`を実行する
+      // その際、今回のターンの`KeyboardEvent`は次回のターンで再利用する
+      // 例
+      // 1. 前回のターン
+      //   - sequence: "d"
+      //   - filtered: ["d","dd"]
+      // 2. 今回のターン
+      //   - sequence: "da"
+      //   - filtered: []
+      // このときは"d"を実行し、状態をリセットしたあと、次回のターンで"a"が入力されたことにする
+      this.prevBestMatchCommand();
       if (size === 0) {
-        handleKeydown(e);
+        this.handleKeydown(e);
         return;
       }
       return;
     }
-    if (filtered.size === 0) {
-      reset();
+    if (size === 0) {
+      // 候補がなければ初期状態に戻す
+      this.backToInitial();
       return;
     }
+    // コマンドを絞り込めきれない場合は、常にdefaultの挙動を打ち消しておく
     e.preventDefault();
     e.stopPropagation();
-    if (bestMatchCommand) {
-      const command = bestMatchCommand;
-      timer = setTimeout(command, interval);
+    this.timer = setTimeout(
+      // 一定時間経っても入力がないときは、初期状態に戻す
+      // もし完全一致するコマンドがあれば、そのコマンドを実行する
+      this.prevBestMatchCommand ?? this.backToInitial,
+      this.flushInterval,
+    );
+  };
+
+  private emitChange = () => {
+    if (this.bindings.size === 0) {
+      this.backToInitial();
+      this.target.removeEventListener(
+        "keydown",
+        this.handleKeydown as EventListener,
+      );
       return;
     }
-    timer = setTimeout(reset, interval);
-  };
 
-  init.target.addEventListener("keydown", handleKeydown as EventListener);
-  return {
-    ok: true,
-    value: () => {
-      init.target.removeEventListener(
-        "keydown",
-        handleKeydown as EventListener,
-      );
-    },
+    this.target.addEventListener(
+      "keydown",
+      this.handleKeydown as EventListener,
+    );
   };
-};
+}
 
 const checkKeyBindings = (
-  keyBindings: Record<string, Command> | Map<string, Command>,
+  keyBindings: KeyBindings,
 ):
   | Map<string, Command>
   | [string, string][] => {


### PR DESCRIPTION
close [✅️初期化後にもkey bindingsを追加できるようにする (takker99/ScrapBindings)](https://scrapbox.io/takker/✅️初期化後にもkey_bindingsを追加できるようにする_(takker99%2FScrapBindings))

BREAKING CHANGE: To bind commands after making the instance, turn just a object into class implemet